### PR TITLE
Accessible hashes

### DIFF
--- a/lib/json/api/attributes.rb
+++ b/lib/json/api/attributes.rb
@@ -8,6 +8,8 @@ module JSON
         fail InvalidDocument,
              "the value of 'attributes' MUST be an object" unless
           attributes_hash.is_a?(Hash)
+
+        @hash = attributes_hash
         @attributes = {}
         attributes_hash.each do |attr_name, attr_val|
           @attributes[attr_name.to_s] = attr_val
@@ -15,6 +17,10 @@ module JSON
             @attributes[attr_name.to_s]
           end
         end
+      end
+
+      def to_hash
+        @hash
       end
 
       def each(&block)

--- a/lib/json/api/document.rb
+++ b/lib/json/api/document.rb
@@ -5,8 +5,8 @@ module JSON
       attr_reader :data, :meta, :errors, :json_api, :links, :included
 
       def initialize(document_hash, options = {})
+        @hash = document_hash
         @options = options
-
         @data_defined = document_hash.key?('data')
         @data = parse_data(document_hash['data']) if @data_defined
         @meta_defined = document_hash.key?('meta')
@@ -23,6 +23,10 @@ module JSON
           @included_defined
 
         validate!
+      end
+
+      def to_hash
+        @hash
       end
 
       def collection?

--- a/lib/json/api/error.rb
+++ b/lib/json/api/error.rb
@@ -8,6 +8,8 @@ module JSON
         fail InvalidDocument,
              "the value of 'errors' MUST be an array of error objects" unless
           error_hash.is_a?(Hash)
+
+        @hash = error_hash
         @id = error_hash['id'] if error_hash.key?('id')
         links_hash = error_hash['links'] || {}
         @links = Links.new(links_hash, options)
@@ -17,6 +19,10 @@ module JSON
         @detail = error_hash['detail'] if error_hash.key?('detail')
         @source = error_hash['source'] if error_hash.key?('source')
         @meta = error_hash['meta'] if error_hash.key?('meta')
+      end
+
+      def to_hash
+        @hash
       end
     end
   end

--- a/lib/json/api/jsonapi.rb
+++ b/lib/json/api/jsonapi.rb
@@ -7,8 +7,14 @@ module JSON
       def initialize(jsonapi_hash, options = {})
         fail InvalidDocument, "the value of 'jsonapi' MUST be an object" unless
           jsonapi_hash.is_a?(Hash)
+
+        @hash = jsonapi_hash
         @version = jsonapi_hash['version'] if jsonapi_hash.key?('meta')
         @meta = jsonapi_hash['meta'] if jsonapi_hash.key?('meta')
+      end
+
+      def to_hash
+        @hash
       end
     end
   end

--- a/lib/json/api/link.rb
+++ b/lib/json/api/link.rb
@@ -5,12 +5,18 @@ module JSON
       attr_reader :value, :href, :meta
 
       def initialize(link_hash, options = {})
+        @hash = link_hash
+
         validate!(link_hash)
         @value = link_hash
         return unless link_hash.is_a?(Hash)
 
         @href = link_hash['href']
         @meta = link_hash['meta']
+      end
+
+      def to_hash
+        @hash
       end
 
       private

--- a/lib/json/api/links.rb
+++ b/lib/json/api/links.rb
@@ -5,6 +5,8 @@ module JSON
       def initialize(links_hash, options = {})
         fail InvalidDocument, "the value of 'links' MUST be an object" unless
           links_hash.is_a?(Hash)
+
+        @hash = links_hash
         @links = {}
         links_hash.each do |link_name, link_val|
           @links[link_name.to_s] = Link.new(link_val, options)
@@ -12,6 +14,10 @@ module JSON
             @links[link_name.to_s]
           end
         end
+      end
+
+      def to_hash
+        @hash
       end
 
       def defined?(link_name)

--- a/lib/json/api/relationship.rb
+++ b/lib/json/api/relationship.rb
@@ -5,6 +5,7 @@ module JSON
       attr_reader :data, :links, :meta
 
       def initialize(relationship_hash, options = {})
+        @hash = relationship_hash
         @options = options
         @links_defined = relationship_hash.key?('links')
         @data_defined = relationship_hash.key?('data')
@@ -16,6 +17,10 @@ module JSON
         @meta = relationship_hash['meta'] if @meta_defined
 
         validate!
+      end
+
+      def to_hash
+        @hash
       end
 
       def collection?

--- a/lib/json/api/relationships.rb
+++ b/lib/json/api/relationships.rb
@@ -8,6 +8,8 @@ module JSON
         fail InvalidDocument,
              "the value of 'relationships' MUST be an object" unless
           relationships_hash.is_a?(Hash)
+
+        @hash = relationships_hash
         @relationships = {}
         relationships_hash.each do |rel_name, rel_hash|
           @relationships[rel_name.to_s] = Relationship.new(rel_hash, options)
@@ -15,6 +17,10 @@ module JSON
             @relationships[rel_name.to_s]
           end
         end
+      end
+
+      def to_hash
+        @hash
       end
 
       def each(&block)

--- a/lib/json/api/resource.rb
+++ b/lib/json/api/resource.rb
@@ -7,6 +7,7 @@ module JSON
       attr_reader :id, :type, :attributes, :relationships, :links, :meta
 
       def initialize(resource_hash, options = {})
+        @hash = resource_hash
         @options = options.dup
         @id_optional = @options.delete(:id_optional)
         validate!(resource_hash)
@@ -19,6 +20,10 @@ module JSON
         @links_hash = resource_hash['links'] || {}
         @links = Links.new(@links_hash, @options)
         @meta = resource_hash['meta'] if resource_hash.key?('meta')
+      end
+
+      def to_hash
+        @hash
       end
 
       private

--- a/lib/json/api/resource_identifier.rb
+++ b/lib/json/api/resource_identifier.rb
@@ -5,10 +5,16 @@ module JSON
       attr_reader :id, :type
 
       def initialize(resource_identifier_hash, options = {})
+        @hash = resource_identifier_hash
+
         validate!(resource_identifier_hash)
 
         @id = resource_identifier_hash['id']
         @type = resource_identifier_hash['type']
+      end
+
+      def to_hash
+        @hash
       end
 
       private

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -2,43 +2,47 @@ require 'json/api'
 
 describe JSON::API, '#parse' do
   before(:all) do
-    @payload = {
-      'data' => [
-        {
-          'type' => 'articles',
-          'id' => '1',
-          'attributes' => {
-            'title' => 'JSON API paints my bikeshed!'
-          },
-          'links' => {
-            'self' => 'http://example.com/articles/1'
-          },
-          'relationships' => {
-            'author' => {
-              'links' => {
-                'self' => 'http://example.com/articles/1/relationships/author',
-                'related' => 'http://example.com/articles/1/author'
-              },
-              'data' => { 'type' => 'people', 'id' => '9' }
-            },
-            'journal' => {
-              'data' => nil
-            },
-            'comments' => {
-              'links' => {
-                'self' => 'http://example.com/articles/1/relationships/comments',
-                'related' => 'http://example.com/articles/1/comments'
-              },
-              'data' => [
-                { 'type' => 'comments', 'id' => '5' },
-                { 'type' => 'comments', 'id' => '12' }
-              ]
-            }
-          }
-        }],
-      'meta' => {
-        'count' => '13'
+    @author_links_hash = {
+      'self' => 'http://example.com/articles/1/relationships/author',
+      'related' => 'http://example.com/articles/1/author'
+    }
+    @author_data_hash = { 'type' => 'people', 'id' => '9' }
+    @comments_data_hash = [
+      { 'type' => 'comments', 'id' => '5' },
+      { 'type' => 'comments', 'id' => '12' }
+    ]
+    @article_relationships_hash = {
+      'author' => {
+        'links' => @author_links_hash,
+        'data' => @author_data_hash
+      },
+      'journal' => {
+        'data' => nil
+      },
+      'comments' => {
+        'links' => {
+          'self' => 'http://example.com/articles/1/relationships/comments',
+          'related' => 'http://example.com/articles/1/comments'
+        },
+        'data' => @comments_data_hash
       }
+    }
+    @article_attributes_hash = { 'title' => 'JSON API paints my bikeshed!' }
+    @article_links_hash = { 'self' => 'http://example.com/articles/1' }
+    @data_hash = [{
+      'type' => 'articles',
+      'id' => '1',
+      'attributes' => @article_attributes_hash,
+      'links' => @article_links_hash,
+      'relationships' => @article_relationships_hash
+    }]
+    @meta_hash = {
+      'count' => '13'
+    }
+
+    @payload = {
+      'data' => @data_hash,
+      'meta' => @meta_hash
     }
   end
 
@@ -78,5 +82,16 @@ describe JSON::API, '#parse' do
     expect(document.data.first.relationships.defined?(:journal)).to be_truthy
     expect(document.data.first.relationships.journal.collection?).to be_falsy
     expect(document.data.first.relationships.journal.data).to eq nil
+
+    expect(document.to_hash).to eq @payload
+    expect(document.data.map(&:to_hash)).to eq @data_hash
+
+    expect(document.data.first.attributes.to_hash).to eq @article_attributes_hash
+    expect(document.data.first.links.to_hash).to eq @article_links_hash
+    expect(document.data.first.relationships.to_hash).to eq @article_relationships_hash
+
+    expect(document.data.first.relationships.author.links.to_hash).to eq @author_links_hash
+    expect(document.data.first.relationships.author.data.to_hash).to eq @author_data_hash
+    expect(document.data.first.relationships.comments.data.map(&:to_hash)).to eq @comments_data_hash
   end
 end


### PR DESCRIPTION
This PR makes accessible:
`@attributes_hash`, `@links_hash` and `@relationships_hash` from `JSON::API::Resource`
`@data_hash` and `@links_hash` from `JSON::API::Relationship`

Motivation:
Hash API is way more generic and can be used directly by `Sequel` or `ActiveRecord` for example. Getting these hashes from the `JSON::API::Document` is much nicer than keeping both `JSON::API::Document` and whatever hash it originally parsed in your application. You can now pass around `JSON::API::Document` objects within your application without having to access `@the_original_hash_or_json_string` as well.

Tests added. Let me know if there is something to be improved or clarified.