### PR TITLE
Fix `Resource#to_activerecord_hash`.

### DIFF
--- a/lib/json/api/resource/active_record.rb
+++ b/lib/json/api/resource/active_record.rb
@@ -66,6 +66,8 @@ module JSON
       #   * :key_formatter (lambda)
       # @return [Hash]
       def to_activerecord_hash(options = {})
+        options[:attributes] ||= {}
+        options[:relationships] ||= {}
         hash = {}
         hash[:id] = id unless id.nil?
         hash.merge!(attributes_for_activerecord_hash(options))

--- a/spec/resource/to_activerecord_hash_spec.rb
+++ b/spec/resource/to_activerecord_hash_spec.rb
@@ -56,4 +56,21 @@ describe JSON::API::Resource, '.to_activerecord_hash' do
 
     expect(actual).to eq expected
   end
+
+  it 'whitelists all attributes/relationships by default' do
+    document = JSON::API.parse(@payload)
+
+    actual = document.data.to_activerecord_hash
+    expected = {
+      id: '1',
+      title: 'JSON API paints my bikeshed!',
+      rating: '5 stars',
+      author_id: '9',
+      referree_id: nil,
+      :'publishing-journal_id' => nil,
+      comment_ids: ['5', '12']
+    }
+
+    expect(actual).to eq expected
+  end
 end


### PR DESCRIPTION
Fixes #9 – `Resource#to_activerecord_hash` previously expected the `attributes` and `relationships` to be explicitly black/whitelisted.